### PR TITLE
fix: add Windows compatibility for spawn and path handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "im-hub",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Universal messenger-to-agent bridge — connect WeChat/Feishu/Telegram to Claude Code/Codex/Copilot",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import { readFile, writeFile, mkdir } from 'fs/promises'
 import { registry } from './core/registry.js'
 import { sessionManager } from './core/session.js'
 import { parseMessage, routeMessage } from './core/router.js'
+import { crossSpawn } from './utils/cross-platform.js'
 import type { MessageContext } from './core/types.js'
 
 const CONFIG_DIR = join(homedir(), '.im-hub')
@@ -278,8 +279,7 @@ program
       case 'claude':
         console.log('🤖 Configuring Claude Code agent...')
         // Check if claude CLI is available
-        const { spawn } = await import('child_process')
-        const checkClaude = spawn('claude', ['--version'], { stdio: 'ignore' })
+        const checkClaude = crossSpawn('claude', ['--version'], { stdio: 'ignore' })
         checkClaude.on('close', (code) => {
           if (code === 0) {
             console.log('✅ Claude Code CLI found!')
@@ -296,8 +296,7 @@ program
 
       case 'codex':
         console.log('🤖 Configuring Codex agent...')
-        const { spawn: spawnCodex } = await import('child_process')
-        const checkCodex = spawnCodex('codex', ['--version'], { stdio: 'ignore' })
+        const checkCodex = crossSpawn('codex', ['--version'], { stdio: 'ignore' })
         checkCodex.on('close', (code) => {
           if (code === 0) {
             console.log('✅ Codex CLI found!')

--- a/src/plugins/agents/claude-code/index.ts
+++ b/src/plugins/agents/claude-code/index.ts
@@ -1,8 +1,8 @@
 // Claude Code agent adapter
 // Uses --print --output-format stream-json for programmatic interaction
 
-import { spawn } from 'child_process'
 import type { AgentAdapter } from '../../../core/types.js'
+import { crossSpawn } from '../../../utils/cross-platform.js'
 
 interface ClaudeMessage {
   type: string
@@ -22,7 +22,7 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 
   async isAvailable(): Promise<boolean> {
     return new Promise((resolve) => {
-      const proc = spawn('claude', ['--version'], { stdio: 'ignore' })
+      const proc = crossSpawn('claude', ['--version'], { stdio: 'ignore' })
       proc.on('close', (code) => resolve(code === 0))
       proc.on('error', () => resolve(false))
     })
@@ -42,7 +42,7 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 
   private callClaude(prompt: string): Promise<string> {
     return new Promise((resolve, reject) => {
-      const proc = spawn('claude', [
+      const proc = crossSpawn('claude', [
         '--print',
         '--verbose',
         '--output-format', 'stream-json',
@@ -55,7 +55,7 @@ export class ClaudeCodeAdapter implements AgentAdapter {
       let stderr = ''
       let fullText = ''
 
-      proc.stdout.on('data', (data: Buffer) => {
+      proc.stdout?.on('data', (data: Buffer) => {
         stdout += data.toString()
         const lines = stdout.split('\n')
         stdout = lines.pop() || ''
@@ -76,7 +76,7 @@ export class ClaudeCodeAdapter implements AgentAdapter {
         }
       })
 
-      proc.stderr.on('data', (data: Buffer) => {
+      proc.stderr?.on('data', (data: Buffer) => {
         stderr += data.toString()
         console.error('[ClaudeCode stderr]', data.toString())
       })

--- a/src/plugins/agents/codex/index.ts
+++ b/src/plugins/agents/codex/index.ts
@@ -1,8 +1,8 @@
 // OpenAI Codex CLI agent adapter
 // Uses `codex exec --json` for programmatic interaction
 
-import { spawn } from 'child_process'
 import type { AgentAdapter } from '../../../core/types.js'
+import { crossSpawn } from '../../../utils/cross-platform.js'
 
 interface CodexEvent {
   type: string
@@ -20,7 +20,7 @@ export class CodexAdapter implements AgentAdapter {
 
   async isAvailable(): Promise<boolean> {
     return new Promise((resolve) => {
-      const proc = spawn('codex', ['--version'], { stdio: 'ignore' })
+      const proc = crossSpawn('codex', ['--version'], { stdio: 'ignore' })
       proc.on('close', (code) => resolve(code === 0))
       proc.on('error', () => resolve(false))
     })
@@ -39,7 +39,7 @@ export class CodexAdapter implements AgentAdapter {
 
   private callCodex(prompt: string): Promise<string> {
     return new Promise((resolve, reject) => {
-      const proc = spawn('codex', [
+      const proc = crossSpawn('codex', [
         'exec',
         '--json',
         '--full-auto',
@@ -54,7 +54,7 @@ export class CodexAdapter implements AgentAdapter {
       let fullText = ''
       let errorMessage = ''
 
-      proc.stdout.on('data', (data: Buffer) => {
+      proc.stdout?.on('data', (data: Buffer) => {
         stdout += data.toString()
         const lines = stdout.split('\n')
         stdout = lines.pop() || ''
@@ -82,7 +82,7 @@ export class CodexAdapter implements AgentAdapter {
         }
       })
 
-      proc.stderr.on('data', (data: Buffer) => {
+      proc.stderr?.on('data', (data: Buffer) => {
         stderr += data.toString()
         console.error('[Codex stderr]', data.toString())
       })

--- a/src/plugins/agents/copilot/index.ts
+++ b/src/plugins/agents/copilot/index.ts
@@ -1,16 +1,69 @@
 // GitHub Copilot CLI agent adapter
 // Uses `copilot -p "prompt" -s` for programmatic interaction
 
-import { spawn } from 'child_process'
+import { access, constants, readdir } from 'fs/promises'
 import { homedir } from 'os'
 import { join } from 'path'
 import type { AgentAdapter } from '../../../core/types.js'
+import { crossSpawn, isWindows, isMac } from '../../../utils/cross-platform.js'
 
-// Copilot CLI binary path (installed by VS Code extension)
-const COPILOT_BIN = join(
-  homedir(),
-  'Library/Application Support/Code/User/globalStorage/github.copilot-chat/copilotCli/copilot'
-)
+/**
+ * Get Copilot CLI binary path based on the current platform.
+ * Copilot CLI is installed by VS Code extension in different locations per OS.
+ */
+async function findCopilotBin(): Promise<string | null> {
+  // macOS: standard location
+  if (isMac) {
+    const macPath = join(
+      homedir(),
+      'Library/Application Support/Code/User/globalStorage/github.copilot-chat/copilotCli/copilot'
+    )
+    try {
+      await access(macPath, constants.X_OK)
+      return macPath
+    } catch {
+      return null
+    }
+  }
+
+  // Windows: need to find the extension folder (versioned)
+  if (isWindows) {
+    const extensionsDir = join(homedir(), '.vscode', 'extensions')
+    try {
+      const entries = await readdir(extensionsDir, { withFileTypes: true })
+      // Find copilot-chat extension folder (versioned, e.g., github.copilot-chat-0.20.0)
+      const copilotDir = entries.find(
+        (entry) => entry.isDirectory() && entry.name.startsWith('github.copilot-chat-')
+      )
+      if (copilotDir) {
+        const copilotBin = join(extensionsDir, copilotDir.name, 'copilotCli', 'copilot.exe')
+        try {
+          await access(copilotBin, constants.X_OK)
+          return copilotBin
+        } catch {
+          // Binary not executable, continue
+        }
+      }
+    } catch {
+      // Ignore readdir errors
+    }
+  }
+
+  // Linux: standard location
+  const linuxPath = join(
+    homedir(),
+    '.vscode/extensions/github.copilot-chat/copilotCli/copilot'
+  )
+  try {
+    await access(linuxPath, constants.X_OK)
+    return linuxPath
+  } catch {
+    return null
+  }
+}
+
+// Cached binary path
+let cachedCopilotBin: string | null = null
 
 export class CopilotAdapter implements AgentAdapter {
   readonly name = 'copilot'
@@ -18,19 +71,28 @@ export class CopilotAdapter implements AgentAdapter {
 
   async isAvailable(): Promise<boolean> {
     // Check if binary exists (don't require quota to pass availability check)
-    const fs = await import('fs')
-    try {
-      await fs.promises.access(COPILOT_BIN, fs.constants.X_OK)
-      return true
-    } catch {
-      return false
+    if (!cachedCopilotBin) {
+      cachedCopilotBin = await findCopilotBin()
     }
+    return cachedCopilotBin !== null
   }
 
   async *sendPrompt(_sessionId: string, prompt: string): AsyncGenerator<string> {
     console.log(`[Copilot] sendPrompt called, prompt: ${prompt}`)
 
-    const response = await this.callCopilot(prompt)
+    if (!cachedCopilotBin) {
+      cachedCopilotBin = await findCopilotBin()
+    }
+
+    if (!cachedCopilotBin) {
+      yield `❌ Copilot CLI 未找到。
+
+请确保已安装 VS Code Copilot Chat 扩展。
+${isWindows ? 'Windows 用户请确保扩展安装在 %USERPROFILE%\\.vscode\\extensions 目录下。' : ''}`
+      return
+    }
+
+    const response = await this.callCopilot(prompt, cachedCopilotBin)
     console.log(`[Copilot] Response length: ${response.length}`)
 
     if (response) {
@@ -38,9 +100,9 @@ export class CopilotAdapter implements AgentAdapter {
     }
   }
 
-  private callCopilot(prompt: string): Promise<string> {
+  private callCopilot(prompt: string, copilotBin: string): Promise<string> {
     return new Promise((resolve, reject) => {
-      const proc = spawn(COPILOT_BIN, [
+      const proc = crossSpawn(copilotBin, [
         '-p', prompt,
         '-s',  // suppress stats, output only response
       ], {
@@ -50,11 +112,11 @@ export class CopilotAdapter implements AgentAdapter {
       let stdout = ''
       let stderr = ''
 
-      proc.stdout.on('data', (data: Buffer) => {
+      proc.stdout?.on('data', (data: Buffer) => {
         stdout += data.toString()
       })
 
-      proc.stderr.on('data', (data: Buffer) => {
+      proc.stderr?.on('data', (data: Buffer) => {
         stderr += data.toString()
         console.error('[Copilot stderr]', data.toString())
       })

--- a/src/plugins/agents/opencode/index.ts
+++ b/src/plugins/agents/opencode/index.ts
@@ -1,8 +1,8 @@
 // OpenCode CLI agent adapter
 // Uses `opencode run --format json` for programmatic interaction
 
-import { spawn } from 'child_process'
 import type { AgentAdapter } from '../../../core/types.js'
+import { crossSpawn } from '../../../utils/cross-platform.js'
 
 interface OpenCodePart {
   type: string
@@ -24,7 +24,7 @@ export class OpenCodeAdapter implements AgentAdapter {
 
   async isAvailable(): Promise<boolean> {
     return new Promise((resolve) => {
-      const proc = spawn('opencode', ['--version'], { stdio: 'ignore' })
+      const proc = crossSpawn('opencode', ['--version'], { stdio: 'ignore' })
       proc.on('close', (code) => resolve(code === 0))
       proc.on('error', () => resolve(false))
     })
@@ -43,7 +43,7 @@ export class OpenCodeAdapter implements AgentAdapter {
 
   private callOpenCode(prompt: string): Promise<string> {
     return new Promise((resolve, reject) => {
-      const proc = spawn('opencode', [
+      const proc = crossSpawn('opencode', [
         'run',
         '--format', 'json',
         prompt,
@@ -56,7 +56,7 @@ export class OpenCodeAdapter implements AgentAdapter {
       let fullText = ''
       let errorMessage = ''
 
-      proc.stdout.on('data', (data: Buffer) => {
+      proc.stdout?.on('data', (data: Buffer) => {
         stdout += data.toString()
         const lines = stdout.split('\n')
         stdout = lines.pop() || ''
@@ -83,7 +83,7 @@ export class OpenCodeAdapter implements AgentAdapter {
         }
       })
 
-      proc.stderr.on('data', (data: Buffer) => {
+      proc.stderr?.on('data', (data: Buffer) => {
         stderr += data.toString()
         console.error('[OpenCode stderr]', data.toString())
       })

--- a/src/utils/cross-platform.ts
+++ b/src/utils/cross-platform.ts
@@ -1,0 +1,76 @@
+// Cross-platform utilities for Windows compatibility
+
+import { spawn, SpawnOptions, ChildProcess } from 'child_process'
+import { platform, homedir } from 'os'
+import { join } from 'path'
+
+export const isWindows = platform() === 'win32'
+export const isMac = platform() === 'darwin'
+export const isLinux = platform() === 'linux'
+
+/**
+ * Cross-platform spawn wrapper that automatically handles Windows compatibility.
+ * On Windows, it sets shell: true to enable command execution.
+ *
+ * Note: When using stdio: ['ignore', 'pipe', 'pipe'], stdout and stderr are guaranteed to be non-null.
+ */
+export function crossSpawn(
+  command: string,
+  args: string[] = [],
+  options: SpawnOptions = {}
+): ChildProcess {
+  const spawnOptions: SpawnOptions = {
+    ...options,
+    // On Windows, we need shell: true for commands like 'claude', 'opencode', etc.
+    // to be found in PATH and executed properly.
+    shell: isWindows ? (options.shell ?? true) : options.shell,
+  }
+  return spawn(command, args, spawnOptions)
+}
+
+/**
+ * Get Copilot CLI binary path based on the current platform.
+ * Copilot CLI is installed by VS Code extension in different locations per OS.
+ */
+export function getCopilotBinPath(): string {
+  if (isWindows) {
+    // Windows: VS Code extensions are in %USERPROFILE%\.vscode\extensions
+    // The copilot CLI should be in the global storage
+    return join(
+      homedir(),
+      '.vscode',
+      'extensions',
+      'github.copilot-chat-*/copilotCli/copilot.exe'
+    )
+  } else if (isMac) {
+    // macOS
+    return join(
+      homedir(),
+      'Library/Application Support/Code/User/globalStorage/github.copilot-chat/copilotCli/copilot'
+    )
+  } else {
+    // Linux
+    return join(
+      homedir(),
+      '.vscode/extensions/github.copilot-chat/copilotCli/copilot'
+    )
+  }
+}
+
+/**
+ * Check if a command exists in PATH.
+ * Uses 'where' on Windows, 'which' on Unix.
+ */
+export function commandExists(command: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const checkCmd = isWindows ? 'where' : 'which'
+    const proc = crossSpawn(checkCmd, [command], { stdio: 'ignore' })
+    proc.on('close', (code) => resolve(code === 0))
+    proc.on('error', () => resolve(false))
+  })
+}
+
+/**
+ * Get the correct newline character for the current platform.
+ */
+export const EOL = isWindows ? '\r\n' : '\n'


### PR DESCRIPTION
- Add cross-platform utility module (src/utils/cross-platform.ts)
  - Platform detection: isWindows, isMac, isLinux
  - crossSpawn: auto-enables shell:true on Windows for CLI commands
  - commandExists: cross-platform command check (where/which)

- Fix Copilot CLI path detection for all platforms
  - macOS: ~/Library/Application Support/Code/...
  - Windows: ~/.vscode/extensions/github.copilot-chat-*/copilotCli/copilot.exe
  - Linux: ~/.vscode/extensions/github.copilot-chat/copilotCli/copilot

- Update all agent adapters to use crossSpawn
  - claude-code, codex, opencode, copilot adapters
  - cli.ts configuration checks

- Bump version to 0.1.10