### PR TITLE
fix: keep Telegram config prompt open until channel ID is entered

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -388,7 +388,6 @@ program
 
         const token = await new Promise<string>((resolve) => {
           rl.question('Enter your bot token: ', (answer) => {
-            rl.close()
             resolve(answer.trim())
           })
         })
@@ -403,6 +402,8 @@ program
             resolve(answer.trim() || 'default')
           })
         })
+
+        rl.close()
 
         config.telegram = { botToken: token, channelId }
         if (!config.messengers.includes('telegram')) {


### PR DESCRIPTION
## Summary
- keep the Telegram config readline session open until both prompts finish
- avoid closing the prompt immediately after the bot token, which breaks the optional channel ID step
- verified the change by rebuilding the project with `npm run build`