### PR TITLE
feat: add bilingual web chat UI with i18n support (zh/en)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ im-hub config wechat   # Scan QR to login
 im-hub start           # Start the bridge
 ```
 
+## Web Chat
+
+im-hub includes a built-in web interface for chatting with your agents directly from the browser.
+
+```
+im-hub start           # Starts web UI at http://localhost:3000
+```
+
+Features:
+- Real-time streaming responses via WebSocket
+- Agent switching and chat history
+- Settings page for managing agents, messengers, and ACP connections
+- Bilingual UI (English / Chinese) — auto-detects your browser language
+
 ## Features
 
 - **Universal multiplexer** — one instance, multiple messengers, multiple agents
@@ -172,7 +186,12 @@ im-hub/
 │   │       ├── copilot/          # GitHub Copilot adapter
 │   │       └── opencode/         # OpenCode adapter
 │   ├── index.ts                  # Main entry
-│   └── cli.ts                    # CLI commands
+│   ├── cli.ts                    # CLI commands
+│   └── web/
+│       ├── server.ts             # Web chat HTTP + WebSocket server
+│       └── public/
+│           ├── index.html         # Chat UI (bilingual)
+│           └── settings.html      # Settings UI (bilingual)
 ├── package.json
 ├── tsconfig.json
 └── README.md
@@ -239,6 +258,11 @@ npm start
 - [x] Telegram adapter
 - [x] Session persistence with conversation history
 - [x] ACP custom agent support
+
+### v0.2.x
+- [x] Web Chat UI — browser-based agent chat with streaming responses
+- [x] Settings page — configure agents, messengers, and ACP from the browser
+- [x] Bilingual UI — English/Chinese with automatic browser language detection
 
 ### v0.3.0
 - [ ] DingTalk adapter

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -37,6 +37,20 @@ im-hub config wechat   # 扫码登录微信
 im-hub start           # 启动桥接
 ```
 
+## Web 对话
+
+im-hub 内置 Web 界面，可直接在浏览器中与 Agent 对话。
+
+```
+im-hub start           # 启动后访问 http://localhost:3000
+```
+
+功能：
+- 通过 WebSocket 实时流式响应
+- Agent 切换与对话历史
+- 设置页面管理 Agent、消息通道和 ACP 连接
+- 双语界面（中文 / English）——自动检测浏览器语言
+
 ## 核心特性
 
 - **多路复用** — 一个实例，同时对接多个 IM 和多个 Agent
@@ -171,7 +185,12 @@ im-hub/
 │   │       ├── copilot/          # Copilot 适配器
 │   │       └── opencode/         # OpenCode 适配器
 │   ├── index.ts                  # 主入口
-│   └── cli.ts                    # CLI 命令
+│   ├── cli.ts                    # CLI 命令
+│   └── web/
+│       ├── server.ts             # Web 对话 HTTP + WebSocket 服务
+│       └── public/
+│           ├── index.html         # 对话界面（双语）
+│           └── settings.html      # 设置界面（双语）
 ├── package.json
 ├── tsconfig.json
 └── README.md
@@ -238,6 +257,11 @@ npm start
 - [x] Telegram 适配器
 - [x] 会话持久化与对话历史
 - [x] ACP 自定义 Agent 接入
+
+### v0.2.x
+- [x] Web 对话界面 —— 浏览器端 Agent 对话，支持流式响应
+- [x] 设置页面 —— 在浏览器中配置 Agent、消息通道和 ACP
+- [x] 双语界面 —— 中英文自动检测浏览器语言
 
 ### v0.3.0
 - [ ] 钉钉适配器

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@larksuiteoapi/node-sdk": "^1.59.0",
         "commander": "^11.0.0",
         "grammy": "^1.41.1",
-        "marked": "^17.0.5"
+        "marked": "^17.0.5",
+        "ws": "^8.20.0"
       },
       "bin": {
         "im-hub": "dist/cli.js"
@@ -21,6 +22,7 @@
         "@types/bun": "^1.2.0",
         "@types/marked": "^5.0.2",
         "@types/node": "^20.0.0",
+        "@types/ws": "^8.18.1",
         "typescript": "^5.0.0"
       },
       "engines": {
@@ -132,6 +134,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/abort-controller": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && rm -rf dist/web/public && cp -r src/web/public dist/web/public",
     "dev": "tsc --watch",
     "start": "node dist/cli.js",
     "test": "echo \"No tests yet\"",
@@ -41,12 +41,14 @@
     "@larksuiteoapi/node-sdk": "^1.59.0",
     "commander": "^11.0.0",
     "grammy": "^1.41.1",
-    "marked": "^17.0.5"
+    "marked": "^17.0.5",
+    "ws": "^8.20.0"
   },
   "devDependencies": {
     "@types/bun": "^1.2.0",
     "@types/marked": "^5.0.2",
     "@types/node": "^20.0.0",
+    "@types/ws": "^8.18.1",
     "typescript": "^5.0.0"
   },
   "engines": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@ import {
   saveConfig as saveOnboardingConfig,
   type Config as OnboardingConfig,
 } from './core/onboarding.js'
+import { startWebServer } from './web/server.js'
 
 // Helper to format agent install hint for missing agents
 function formatMissingAgentHint(missing: string[]): string {
@@ -137,13 +138,32 @@ program
       }
     }
 
+    // ============================================
+    // START WEB CHAT SERVER
+    // ============================================
+
+    let webServer: { close: () => void; port: number } | undefined
+    try {
+      webServer = await startWebServer({
+        port: config.webPort as number | undefined,
+        defaultAgent: config.defaultAgent,
+      })
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err)
+      console.warn(`⚠️ Web chat server failed to start: ${errMsg}`)
+    }
+
     console.log('\n✅ IM hub is running!')
+    if (webServer) {
+      console.log(`   Chat UI: http://localhost:${webServer.port}`)
+    }
     console.log('Press Ctrl+C to stop')
 
     // Keep process alive
     process.on('SIGINT', async () => {
       console.log('\n👋 Shutting down...')
       sessionManager.stop()
+      webServer?.close()
 
       // Stop all messengers
       for (const name of registry.listMessengers()) {

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -1,0 +1,642 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>im-hub — Agent Chat</title>
+  <script>
+    // i18n — detect browser language, store preference in localStorage
+    const LANGS = { en: 'English', zh: '中文' };
+    const savedLang = localStorage.getItem('im-hub-lang');
+    const browserLang = navigator.language.startsWith('zh') ? 'zh' : 'en';
+    window.__lang = savedLang && LANGS[savedLang] ? savedLang : browserLang;
+    document.documentElement.lang = window.__lang === 'zh' ? 'zh-CN' : 'en';
+
+    const T = {
+      en: {
+        title: 'im-hub — Agent Chat',
+        connecting: 'Connecting...',
+        connected: 'Connected',
+        disconnected: 'Disconnected',
+        connError: 'Connection error',
+        loadingAgents: 'Loading agents...',
+        newChat: 'New Chat',
+        welcomeTitle: 'im-hub Agent Chat',
+        welcomeDesc: 'Select an agent and start chatting. Your locally installed AI coding agents are ready.',
+        inputPlaceholder: 'Type a message... (Enter to send, Shift+Enter for newline)',
+        send: 'Send',
+        you: 'You',
+        assistant: 'Assistant',
+      },
+      zh: {
+        title: 'im-hub — Agent 对话',
+        connecting: '连接中...',
+        connected: '已连接',
+        disconnected: '已断开',
+        connError: '连接错误',
+        loadingAgents: '加载 Agent...',
+        newChat: '新对话',
+        welcomeTitle: 'im-hub Agent 对话',
+        welcomeDesc: '选择一个 Agent 开始对话，本地安装的 AI 编程助手已就绪。',
+        inputPlaceholder: '输入消息...（Enter 发送，Shift+Enter 换行）',
+        send: '发送',
+        you: '你',
+        assistant: '助手',
+      },
+    };
+    function t(key) { return T[window.__lang][key] || T.en[key] || key; }
+    document.addEventListener('DOMContentLoaded', () => { document.title = t('title'); });
+  </script>
+  <style>
+    :root {
+      --bg: #0a0a0a;
+      --surface: #141414;
+      --surface2: #1e1e1e;
+      --border: #2a2a2a;
+      --text: #e5e5e5;
+      --text-dim: #888;
+      --accent: #6366f1;
+      --accent-dim: #4f46e5;
+      --user-bg: #1a1a2e;
+      --assistant-bg: #1e1e1e;
+      --code-bg: #0d0d0d;
+      --green: #22c55e;
+      --red: #ef4444;
+      --yellow: #eab308;
+    }
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* Header */
+    .header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 12px 20px;
+      border-bottom: 1px solid var(--border);
+      background: var(--surface);
+    }
+    .header-left {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+    .logo {
+      font-weight: 700;
+      font-size: 16px;
+      color: var(--accent);
+    }
+    .status-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--yellow);
+      display: inline-block;
+    }
+    .status-dot.connected { background: var(--green); }
+    .status-dot.disconnected { background: var(--red); }
+    .status-text { font-size: 12px; color: var(--text-dim); }
+    .header-right { display: flex; align-items: center; gap: 10px; }
+
+    /* Agent selector */
+    .agent-select {
+      background: var(--surface2);
+      color: var(--text);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 6px 10px;
+      font-size: 13px;
+      cursor: pointer;
+      outline: none;
+    }
+    .agent-select:focus { border-color: var(--accent); }
+
+    .btn {
+      background: var(--surface2);
+      color: var(--text-dim);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 6px 10px;
+      font-size: 12px;
+      cursor: pointer;
+    }
+    .btn:hover { color: var(--text); border-color: var(--text-dim); }
+
+    /* Language selector */
+    .lang-select {
+      background: var(--surface2);
+      color: var(--text-dim);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 4px 6px;
+      font-size: 12px;
+      cursor: pointer;
+      outline: none;
+    }
+    .lang-select:hover { color: var(--text); }
+
+    /* Messages */
+    .messages {
+      flex: 1;
+      overflow-y: auto;
+      padding: 20px;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    .message {
+      max-width: 85%;
+      padding: 12px 16px;
+      border-radius: 12px;
+      font-size: 14px;
+      line-height: 1.6;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+    .message.user {
+      align-self: flex-end;
+      background: var(--user-bg);
+      border-bottom-right-radius: 4px;
+    }
+    .message.assistant {
+      align-self: flex-start;
+      background: var(--assistant-bg);
+      border-bottom-left-radius: 4px;
+    }
+    .message.assistant code {
+      background: var(--code-bg);
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+      font-size: 13px;
+    }
+    .message.assistant pre {
+      background: var(--code-bg);
+      padding: 12px 16px;
+      border-radius: 8px;
+      overflow-x: auto;
+      margin: 8px 0;
+    }
+    .message.assistant pre code {
+      background: none;
+      padding: 0;
+    }
+
+    .message-label {
+      font-size: 11px;
+      color: var(--text-dim);
+      margin-bottom: 4px;
+      font-weight: 600;
+    }
+
+    /* Typing indicator */
+    .typing {
+      align-self: flex-start;
+      padding: 12px 16px;
+      color: var(--text-dim);
+      font-size: 13px;
+    }
+    .typing span {
+      animation: blink 1.4s infinite;
+    }
+    .typing span:nth-child(2) { animation-delay: 0.2s; }
+    .typing span:nth-child(3) { animation-delay: 0.4s; }
+    @keyframes blink {
+      0%, 60%, 100% { opacity: 0.2; }
+      30% { opacity: 1; }
+    }
+
+    /* Welcome screen */
+    .welcome {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 16px;
+      color: var(--text-dim);
+    }
+    .welcome h2 { color: var(--text); font-size: 20px; }
+    .welcome p { font-size: 14px; max-width: 400px; text-align: center; }
+
+    /* Input area */
+    .input-area {
+      padding: 16px 20px;
+      border-top: 1px solid var(--border);
+      background: var(--surface);
+    }
+    .input-wrapper {
+      display: flex;
+      gap: 8px;
+      align-items: flex-end;
+    }
+    .input-wrapper textarea {
+      flex: 1;
+      background: var(--surface2);
+      color: var(--text);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 10px 14px;
+      font-size: 14px;
+      font-family: inherit;
+      resize: none;
+      outline: none;
+      max-height: 150px;
+      min-height: 42px;
+    }
+    .input-wrapper textarea:focus { border-color: var(--accent); }
+    .input-wrapper textarea::placeholder { color: var(--text-dim); }
+
+    .send-btn {
+      background: var(--accent);
+      color: white;
+      border: none;
+      border-radius: 10px;
+      padding: 10px 16px;
+      font-size: 14px;
+      cursor: pointer;
+      white-space: nowrap;
+    }
+    .send-btn:hover { background: var(--accent-dim); }
+    .send-btn:disabled {
+      background: var(--surface2);
+      color: var(--text-dim);
+      cursor: not-allowed;
+    }
+
+    /* Scrollbar */
+    .messages::-webkit-scrollbar { width: 6px; }
+    .messages::-webkit-scrollbar-track { background: transparent; }
+    .messages::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <div class="header-left">
+      <span class="logo">im-hub</span>
+      <span class="status-dot" id="statusDot"></span>
+      <span class="status-text" id="statusText"></span>
+    </div>
+    <div class="header-right">
+      <select class="lang-select" id="langSelect">
+        <option value="en">EN</option>
+        <option value="zh">中文</option>
+      </select>
+      <select class="agent-select" id="agentSelect" disabled>
+        <option value=""></option>
+      </select>
+      <button class="btn" id="newChatBtn"></button>
+      <a class="btn" href="/settings" title="Settings" style="text-decoration:none;font-size:16px;line-height:1">&#9881;</a>
+    </div>
+  </div>
+
+  <div class="messages" id="messages">
+    <div class="welcome" id="welcome">
+      <h2 id="welcomeTitle"></h2>
+      <p id="welcomeDesc"></p>
+    </div>
+  </div>
+
+  <div class="input-area">
+    <div class="input-wrapper">
+      <textarea
+        id="input"
+        rows="1"
+        disabled
+      ></textarea>
+      <button class="send-btn" id="sendBtn" disabled></button>
+    </div>
+  </div>
+
+  <script>
+    // Apply i18n to static elements
+    function applyLang() {
+      document.title = t('title');
+      document.documentElement.lang = window.__lang === 'zh' ? 'zh-CN' : 'en';
+      statusText.textContent = statusText.dataset.state ? t(statusText.dataset.state) : t('connecting');
+      const opt = agentSelect.querySelector('option[value=""]');
+      if (opt) opt.textContent = t('loadingAgents');
+      newChatBtn.textContent = t('newChat');
+      inputEl.placeholder = t('inputPlaceholder');
+      sendBtn.textContent = t('send');
+      const wt = document.getElementById('welcomeTitle');
+      const wd = document.getElementById('welcomeDesc');
+      if (wt) wt.textContent = t('welcomeTitle');
+      if (wd) wd.textContent = t('welcomeDesc');
+    }
+
+    // State
+    let ws = null;
+    let currentAgent = '';
+    let isStreaming = false;
+    let streamingEl = null;
+    let streamingText = '';
+    let reconnectTimer = null;
+
+    // DOM
+    const messagesEl = document.getElementById('messages');
+    const welcomeEl = document.getElementById('welcome');
+    const inputEl = document.getElementById('input');
+    const sendBtn = document.getElementById('sendBtn');
+    const agentSelect = document.getElementById('agentSelect');
+    const statusDot = document.getElementById('statusDot');
+    const statusText = document.getElementById('statusText');
+    const newChatBtn = document.getElementById('newChatBtn');
+    const langSelect = document.getElementById('langSelect');
+
+    // Language selector
+    langSelect.value = window.__lang;
+    langSelect.addEventListener('change', () => {
+      window.__lang = langSelect.value;
+      localStorage.setItem('im-hub-lang', window.__lang);
+      applyLang();
+    });
+
+    // Connect
+    function connect() {
+      const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+      ws = new WebSocket(`${protocol}//${location.host}`);
+
+      ws.onopen = () => {
+        setStatus('connected', t('connected'));
+        inputEl.disabled = false;
+        sendBtn.disabled = false;
+      };
+
+      ws.onmessage = (e) => {
+        const msg = JSON.parse(e.data);
+        handleMessage(msg);
+      };
+
+      ws.onclose = () => {
+        setStatus('disconnected', t('disconnected'));
+        inputEl.disabled = true;
+        sendBtn.disabled = true;
+        reconnectTimer = setTimeout(connect, 3000);
+      };
+
+      ws.onerror = () => {
+        setStatus('disconnected', t('connError'));
+      };
+    }
+
+    // Handle server messages
+    function handleMessage(msg) {
+      switch (msg.type) {
+        case 'init':
+          agentSelect.innerHTML = '';
+          msg.agents.forEach(name => {
+            const opt = document.createElement('option');
+            opt.value = name;
+            opt.textContent = name;
+            if (name === msg.defaultAgent) opt.selected = true;
+            agentSelect.appendChild(opt);
+          });
+          agentSelect.disabled = false;
+          currentAgent = msg.defaultAgent;
+          break;
+
+        case 'history':
+          hideWelcome();
+          if (msg.agent) {
+            currentAgent = msg.agent;
+            agentSelect.value = msg.agent;
+          }
+          msg.messages.forEach(m => {
+            addMessage(m.role, m.content, false);
+          });
+          scrollToBottom();
+          break;
+
+        case 'agents':
+          agentSelect.innerHTML = '';
+          msg.agents.forEach(name => {
+            const opt = document.createElement('option');
+            opt.value = name;
+            opt.textContent = name;
+            if (name === currentAgent) opt.selected = true;
+            agentSelect.appendChild(opt);
+          });
+          agentSelect.disabled = false;
+          break;
+
+        case 'chunk':
+          if (!isStreaming) {
+            hideWelcome();
+            startStreaming();
+          }
+          streamingText += msg.text;
+          updateStreamingEl();
+          scrollToBottom();
+          break;
+
+        case 'done':
+          if (isStreaming) {
+            finishStreaming();
+          } else if (msg.text) {
+            hideWelcome();
+            addMessage('assistant', msg.text);
+            scrollToBottom();
+          }
+          break;
+
+        case 'error':
+          if (isStreaming) finishStreaming();
+          addMessage('assistant', '\u274c ' + msg.message);
+          scrollToBottom();
+          break;
+
+        case 'agent-switched':
+          currentAgent = msg.agent;
+          agentSelect.value = msg.agent;
+          break;
+      }
+    }
+
+    // Send message
+    function sendMessage() {
+      const text = inputEl.value.trim();
+      if (!text || !ws || ws.readyState !== ws.OPEN) return;
+
+      hideWelcome();
+      addMessage('user', text);
+
+      ws.send(JSON.stringify({
+        type: 'message',
+        text,
+        agent: currentAgent,
+      }));
+
+      inputEl.value = '';
+      autoResize();
+    }
+
+    // Streaming helpers
+    function startStreaming() {
+      isStreaming = true;
+      streamingText = '';
+
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = `<div class="message-label">${t('assistant')}</div>`;
+      streamingEl = document.createElement('div');
+      streamingEl.className = 'message assistant';
+      wrapper.appendChild(streamingEl);
+      messagesEl.appendChild(wrapper);
+    }
+
+    function updateStreamingEl() {
+      if (!streamingEl) return;
+      streamingEl.textContent = streamingText;
+    }
+
+    function finishStreaming() {
+      isStreaming = false;
+      if (streamingEl) {
+        streamingEl.innerHTML = renderMarkdown(streamingText);
+      }
+      streamingEl = null;
+      saveHistory();
+    }
+
+    // Message helpers
+    function addMessage(role, content, save = true) {
+      hideWelcome();
+
+      const wrapper = document.createElement('div');
+      const label = document.createElement('div');
+      label.className = 'message-label';
+      label.textContent = role === 'user' ? t('you') : t('assistant');
+
+      const el = document.createElement('div');
+      el.className = `message ${role}`;
+
+      if (role === 'assistant') {
+        el.innerHTML = renderMarkdown(content);
+      } else {
+        el.textContent = content;
+      }
+
+      wrapper.appendChild(label);
+      wrapper.appendChild(el);
+      messagesEl.appendChild(wrapper);
+
+      if (save) saveHistory();
+    }
+
+    // Basic markdown rendering
+    function renderMarkdown(text) {
+      if (!text) return '';
+      let html = escapeHtml(text);
+
+      html = html.replace(/```(\w*)\n([\s\S]*?)```/g, (_, lang, code) => {
+        return `<pre><code>${code.trim()}</code></pre>`;
+      });
+
+      html = html.replace(/`([^`]+)`/g, '<code>$1</code>');
+      html = html.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+      html = html.replace(/(?<!\*)\*([^*]+)\*(?!\*)/g, '<em>$1</em>');
+
+      return html;
+    }
+
+    function escapeHtml(text) {
+      return text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+    }
+
+    function hideWelcome() {
+      if (welcomeEl) welcomeEl.remove();
+    }
+
+    function scrollToBottom() {
+      requestAnimationFrame(() => {
+        messagesEl.scrollTop = messagesEl.scrollHeight;
+      });
+    }
+
+    // Status
+    function setStatus(state, text) {
+      statusDot.className = `status-dot ${state}`;
+      statusText.textContent = text;
+      statusText.dataset.state = state === 'connected' ? 'connected' : state === 'disconnected' ? 'disconnected' : 'connecting';
+    }
+
+    // LocalStorage persistence
+    function saveHistory() {
+      const msgs = [];
+      messagesEl.querySelectorAll('.message').forEach(el => {
+        const role = el.classList.contains('user') ? 'user' : 'assistant';
+        msgs.push({ role, content: el.textContent });
+      });
+      try {
+        localStorage.setItem('im-hub-history', JSON.stringify(msgs));
+      } catch {}
+    }
+
+    function loadHistory() {
+      try {
+        const saved = localStorage.getItem('im-hub-history');
+        if (saved) {
+          const msgs = JSON.parse(saved);
+          if (msgs.length > 0) {
+            hideWelcome();
+            msgs.forEach(m => addMessage(m.role, m.content, false));
+            scrollToBottom();
+          }
+        }
+      } catch {}
+    }
+
+    // Auto-resize textarea
+    function autoResize() {
+      inputEl.style.height = 'auto';
+      inputEl.style.height = Math.min(inputEl.scrollHeight, 150) + 'px';
+    }
+
+    // Event listeners
+    inputEl.addEventListener('input', autoResize);
+
+    inputEl.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' && !e.shiftKey && !e.isComposing) {
+        e.preventDefault();
+        sendMessage();
+      }
+    });
+
+    sendBtn.addEventListener('click', sendMessage);
+
+    agentSelect.addEventListener('change', () => {
+      const agent = agentSelect.value;
+      if (agent && agent !== currentAgent && ws?.readyState === WebSocket.OPEN) {
+        currentAgent = agent;
+        ws.send(JSON.stringify({ type: 'switch-agent', agent }));
+      }
+    });
+
+    newChatBtn.addEventListener('click', () => {
+      messagesEl.innerHTML = '';
+      localStorage.removeItem('im-hub-history');
+      if (ws?.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: 'message', text: '/new' }));
+      }
+    });
+
+    // Init
+    applyLang();
+    loadHistory();
+    connect();
+  </script>
+</body>
+</html>

--- a/src/web/public/settings.html
+++ b/src/web/public/settings.html
@@ -1,0 +1,892 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>im-hub — Settings</title>
+  <script>
+    const LANGS = { en: 'English', zh: '中文' };
+    const savedLang = localStorage.getItem('im-hub-lang');
+    const browserLang = navigator.language.startsWith('zh') ? 'zh' : 'en';
+    window.__lang = savedLang && LANGS[savedLang] ? savedLang : browserLang;
+    document.documentElement.lang = window.__lang === 'zh' ? 'zh-CN' : 'en';
+
+    const T = {
+      en: {
+        title: 'im-hub — Settings',
+        backToChat: 'Back to Chat',
+        settingsTitle: 'im-hub Settings',
+        loading: 'Loading configuration...',
+        loadFailed: 'Failed to load config',
+        h1: 'Settings',
+        agents: 'Agents',
+        defaultAgent: 'Default Agent',
+        saveAgents: 'Save Agents',
+        messengers: 'Messengers (Channels)',
+        wechat: 'WeChat',
+        wechatHint: 'iLink QR scan login',
+        wechatBox: 'WeChat requires QR scan login. Run <code>im-hub config wechat</code> in terminal to set up.',
+        telegram: 'Telegram',
+        telegramHint: 'Bot token from @BotFather',
+        botToken: 'Bot Token',
+        channelId: 'Channel ID',
+        feishu: 'Feishu / Lark',
+        feishuHint: 'App ID and App Secret',
+        appId: 'App ID',
+        appSecret: 'App Secret',
+        saveMessengers: 'Save Messengers',
+        acpTitle: 'Remote Agents (ACP)',
+        acpNone: 'No remote agents configured',
+        name: 'Name',
+        endpoint: 'Endpoint',
+        auth: 'Auth',
+        enabled: 'Enabled',
+        test: 'Test',
+        del: 'Del',
+        addAgent: 'Add Remote Agent',
+        aliases: 'Aliases (comma-separated)',
+        endpointUrl: 'Endpoint URL',
+        authType: 'Auth Type',
+        none: 'None',
+        apikey: 'API Key',
+        bearer: 'Bearer Token',
+        token: 'Token',
+        testConn: 'Test Connection',
+        add: 'Add Agent',
+        general: 'General',
+        webPort: 'Web Chat Port',
+        save: 'Save',
+        saved: 'Saved',
+        testing: 'Testing...',
+        connected: 'Connected',
+        failed: 'Failed',
+        error: 'Error',
+        savedMsg: 'Saved',
+        saveFailed: 'Save failed',
+        enterEndpoint: 'Enter an endpoint URL',
+        nameRequired: 'Agent name is required',
+        endpointRequired: 'Endpoint URL is required',
+        installHint: 'npm i -g',
+      },
+      zh: {
+        title: 'im-hub — 设置',
+        backToChat: '返回对话',
+        settingsTitle: 'im-hub 设置',
+        loading: '加载配置中...',
+        loadFailed: '加载配置失败',
+        h1: '设置',
+        agents: 'Agent',
+        defaultAgent: '默认 Agent',
+        saveAgents: '保存 Agent',
+        messengers: '消息通道 (Channels)',
+        wechat: '微信',
+        wechatHint: 'iLink 扫码登录',
+        wechatBox: '微信需要扫码登录。在终端运行 <code>im-hub config wechat</code> 进行配置。',
+        telegram: 'Telegram',
+        telegramHint: '从 @BotFather 获取 Bot Token',
+        botToken: 'Bot Token',
+        channelId: '频道 ID',
+        feishu: '飞书 / Lark',
+        feishuHint: 'App ID 和 App Secret',
+        appId: 'App ID',
+        appSecret: 'App Secret',
+        saveMessengers: '保存通道',
+        acpTitle: '远程 Agent (ACP)',
+        acpNone: '暂无远程 Agent',
+        name: '名称',
+        endpoint: '端点',
+        auth: '认证',
+        enabled: '启用',
+        test: '测试',
+        del: '删除',
+        addAgent: '添加远程 Agent',
+        aliases: '别名（逗号分隔）',
+        endpointUrl: '端点 URL',
+        authType: '认证方式',
+        none: '无',
+        apikey: 'API Key',
+        bearer: 'Bearer Token',
+        token: '令牌',
+        testConn: '测试连接',
+        add: '添加 Agent',
+        general: '通用',
+        webPort: 'Web 对话端口',
+        save: '保存',
+        saved: '已保存',
+        testing: '测试中...',
+        connected: '已连接',
+        failed: '失败',
+        error: '错误',
+        savedMsg: '已保存',
+        saveFailed: '保存失败',
+        enterEndpoint: '请输入端点 URL',
+        nameRequired: 'Agent 名称为必填项',
+        endpointRequired: '端点 URL 为必填项',
+        installHint: '安装命令：npm i -g',
+      },
+    };
+    function t(key) { return T[window.__lang][key] || T.en[key] || key; }
+    document.addEventListener('DOMContentLoaded', () => { document.title = t('title'); });
+  </script>
+  <style>
+    :root {
+      --bg: #0a0a0a;
+      --surface: #141414;
+      --surface2: #1e1e1e;
+      --border: #2a2a2a;
+      --text: #e5e5e5;
+      --text-dim: #888;
+      --accent: #6366f1;
+      --accent-dim: #4f46e5;
+      --green: #22c55e;
+      --red: #ef4444;
+      --yellow: #eab308;
+      --radius: 8px;
+    }
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      min-height: 100vh;
+    }
+
+    .header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 12px 24px;
+      border-bottom: 1px solid var(--border);
+      background: var(--surface);
+    }
+    .header a { color: var(--accent); text-decoration: none; font-size: 13px; }
+    .header a:hover { text-decoration: underline; }
+
+    .container {
+      max-width: 720px;
+      margin: 0 auto;
+      padding: 24px;
+    }
+    .container h1 { font-size: 22px; margin-bottom: 24px; }
+
+    /* Cards */
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 20px;
+      margin-bottom: 20px;
+    }
+    .card h2 {
+      font-size: 15px;
+      margin-bottom: 16px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .card h2 .badge {
+      font-size: 11px;
+      padding: 2px 8px;
+      border-radius: 10px;
+      background: var(--surface2);
+      color: var(--text-dim);
+      font-weight: 400;
+    }
+
+    /* Form elements */
+    label {
+      display: block;
+      font-size: 12px;
+      color: var(--text-dim);
+      margin-bottom: 4px;
+      font-weight: 600;
+    }
+    input, select, textarea {
+      width: 100%;
+      background: var(--surface2);
+      color: var(--text);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 8px 12px;
+      font-size: 13px;
+      font-family: inherit;
+      outline: none;
+      margin-bottom: 12px;
+    }
+    input:focus, select:focus, textarea:focus {
+      border-color: var(--accent);
+    }
+    input::placeholder { color: #555; }
+
+    .row {
+      display: flex;
+      gap: 12px;
+    }
+    .row > * { flex: 1; }
+
+    /* Buttons */
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 7px 14px;
+      border-radius: 6px;
+      font-size: 13px;
+      cursor: pointer;
+      border: 1px solid var(--border);
+      background: var(--surface2);
+      color: var(--text);
+      transition: all 0.15s;
+    }
+    .btn:hover { border-color: var(--text-dim); }
+    .btn-primary {
+      background: var(--accent);
+      border-color: var(--accent);
+      color: #fff;
+    }
+    .btn-primary:hover { background: var(--accent-dim); }
+    .btn-danger { color: var(--red); }
+    .btn-danger:hover { background: #1a0a0a; border-color: var(--red); }
+    .btn-sm { padding: 4px 10px; font-size: 12px; }
+    .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+    .actions { display: flex; gap: 8px; margin-top: 12px; }
+
+    /* Status dots */
+    .status { display: inline-flex; align-items: center; gap: 6px; font-size: 13px; }
+    .dot {
+      width: 8px; height: 8px;
+      border-radius: 50%;
+      display: inline-block;
+    }
+    .dot-on { background: var(--green); }
+    .dot-off { background: var(--red); }
+
+    /* Agent list */
+    .agent-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 10px 0;
+      border-bottom: 1px solid var(--border);
+    }
+    .agent-row:last-child { border-bottom: none; }
+    .agent-row .left { display: flex; align-items: center; gap: 10px; }
+    .agent-row .name { font-weight: 600; font-size: 14px; }
+    .agent-row .hint { font-size: 12px; color: var(--text-dim); margin-top: 2px; }
+    .agent-row .aliases { font-size: 11px; color: var(--text-dim); }
+
+    /* ACP table */
+    .acp-table { width: 100%; border-collapse: collapse; margin-bottom: 12px; }
+    .acp-table th {
+      text-align: left;
+      font-size: 11px;
+      color: var(--text-dim);
+      padding: 6px 8px;
+      border-bottom: 1px solid var(--border);
+      font-weight: 600;
+    }
+    .acp-table td {
+      padding: 8px;
+      font-size: 13px;
+      border-bottom: 1px solid var(--border);
+      vertical-align: middle;
+    }
+    .acp-table tr:last-child td { border-bottom: none; }
+
+    /* Toggle */
+    .toggle {
+      position: relative;
+      width: 36px;
+      height: 20px;
+      background: var(--border);
+      border-radius: 10px;
+      cursor: pointer;
+      transition: background 0.2s;
+      flex-shrink: 0;
+    }
+    .toggle.active { background: var(--green); }
+    .toggle::after {
+      content: '';
+      position: absolute;
+      top: 2px; left: 2px;
+      width: 16px; height: 16px;
+      background: #fff;
+      border-radius: 50%;
+      transition: transform 0.2s;
+    }
+    .toggle.active::after { transform: translateX(16px); }
+
+    /* Toast */
+    .toast {
+      position: fixed;
+      bottom: 24px;
+      right: 24px;
+      padding: 10px 18px;
+      border-radius: 8px;
+      font-size: 13px;
+      z-index: 999;
+      opacity: 0;
+      transform: translateY(10px);
+      transition: all 0.3s;
+    }
+    .toast.show { opacity: 1; transform: translateY(0); }
+    .toast.success { background: #0a2a0a; border: 1px solid var(--green); color: var(--green); }
+    .toast.error { background: #2a0a0a; border: 1px solid var(--red); color: var(--red); }
+
+    /* Section hint */
+    .hint-box {
+      background: var(--surface2);
+      border-radius: 6px;
+      padding: 10px 14px;
+      font-size: 12px;
+      color: var(--text-dim);
+      margin-bottom: 12px;
+      line-height: 1.5;
+    }
+    .hint-box code {
+      background: var(--bg);
+      padding: 1px 5px;
+      border-radius: 3px;
+      font-family: 'SF Mono', monospace;
+      font-size: 11px;
+    }
+
+    /* Divider */
+    .divider { border: none; border-top: 1px solid var(--border); margin: 16px 0; }
+
+    /* Loading */
+    .loading {
+      text-align: center;
+      padding: 40px;
+      color: var(--text-dim);
+    }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <a href="/" id="backToChat"></a>
+    <span style="font-weight:600; font-size:15px; color:var(--accent)" id="settingsTitle"></span>
+    <select id="langSelect" style="background:var(--surface2);color:var(--text);border:1px solid var(--border);border-radius:6px;padding:4px 6px;font-size:12px;cursor:pointer;outline:none">
+      <option value="en">EN</option>
+      <option value="zh">中文</option>
+    </select>
+  </div>
+
+  <div class="container" id="app">
+    <div class="loading">Loading configuration...</div>
+  </div>
+
+  <div class="toast" id="toast"></div>
+
+  <script>
+    // Apply i18n to static elements
+    function applyLang() {
+      document.title = t('title');
+      document.documentElement.lang = window.__lang === 'zh' ? 'zh-CN' : 'en';
+      document.getElementById('backToChat').textContent = t('backToChat');
+      document.getElementById('settingsTitle').textContent = t('settingsTitle');
+    }
+
+    // Language selector
+    const langSelect = document.getElementById('langSelect');
+    langSelect.value = window.__lang;
+    langSelect.addEventListener('change', () => {
+      window.__lang = langSelect.value;
+      localStorage.setItem('im-hub-lang', window.__lang);
+      applyLang();
+      render();
+    });
+
+    // State
+    let config = null;
+    let agentStatus = {};
+
+    // DOM
+    const app = document.getElementById('app');
+    const toastEl = document.getElementById('toast');
+
+    // Known built-in agents with install info
+    const BUILTIN_AGENTS = {
+      'claude-code': { aliases: ['cc', 'claude'], pkg: '@anthropic-ai/claude-code', cmd: 'claude' },
+      'codex': { aliases: ['cx'], pkg: '@openai/codex', cmd: 'codex' },
+      'copilot': { aliases: ['co'], pkg: '@github/copilot', cmd: 'copilot' },
+      'opencode': { aliases: ['oc'], pkg: 'opencode-ai', cmd: 'opencode' },
+    };
+
+    // Fetch config on load
+    async function init() {
+      try {
+        const res = await fetch('/api/config');
+        if (!res.ok) throw new Error(t('loadFailed'));
+        const data = await res.json();
+        config = data;
+        agentStatus = data.agentStatus || {};
+        render();
+      } catch (err) {
+        app.innerHTML = `<div class="loading" style="color:var(--red)">${t('loadFailed')}: ${err.message}</div>`;
+      }
+    }
+
+    function render() {
+      app.innerHTML = `
+        <h1>${t('h1')}</h1>
+        ${renderAgentsCard()}
+        ${renderMessengersCard()}
+        ${renderAcpCard()}
+        ${renderGeneralCard()}
+      `;
+      bindEvents();
+    }
+
+    // ==========================================
+    // Agents card
+    // ==========================================
+    function renderAgentsCard() {
+      const agents = Object.keys(BUILTIN_AGENTS);
+      const enabledAgents = config.agents || [];
+      const defaultAgent = config.defaultAgent || 'claude-code';
+
+      const rows = agents.map(name => {
+        const info = BUILTIN_AGENTS[name];
+        const available = agentStatus[name];
+        const enabled = enabledAgents.includes(name);
+
+        return `
+          <div class="agent-row" data-agent="${name}">
+            <div class="left">
+              <span class="dot ${available ? 'dot-on' : 'dot-off'}"></span>
+              <div>
+                <div class="name">${name}</div>
+                <div class="aliases">${info.aliases.map(a => '/' + a).join(', ')}</div>
+                ${!available ? `<div class="hint">${t('installHint')} ${info.pkg}</div>` : ''}
+              </div>
+            </div>
+            <div class="toggle ${enabled ? 'active' : ''}" data-toggle-agent="${name}"></div>
+          </div>
+        `;
+      }).join('');
+
+      return `
+        <div class="card">
+          <h2>${t('agents')} <span class="badge">${agents.length}</span></h2>
+          ${rows}
+          <hr class="divider">
+          <label>${t('defaultAgent')}</label>
+          <select id="defaultAgent">
+            ${agents.filter(a => agentStatus[a]).map(a =>
+              `<option value="${a}" ${a === defaultAgent ? 'selected' : ''}>${a}</option>`
+            ).join('')}
+          </select>
+          <div class="actions">
+            <button class="btn btn-primary" id="saveAgents">${t('saveAgents')}</button>
+          </div>
+        </div>
+      `;
+    }
+
+    // ==========================================
+    // Messengers card
+    // ==========================================
+    function renderMessengersCard() {
+      const messengers = config.messengers || [];
+      const tg = config.telegram || {};
+      const fs = config.feishu || {};
+
+      const wechatEnabled = messengers.includes('wechat-ilink');
+      const telegramEnabled = messengers.includes('telegram');
+      const feishuEnabled = messengers.includes('feishu');
+
+      return `
+        <div class="card">
+          <h2>${t('messengers')} <span class="badge">${messengers.length}</span></h2>
+
+          <!-- WeChat -->
+          <div style="margin-bottom:16px">
+            <div class="agent-row">
+              <div class="left">
+                <div>
+                  <div class="name">${t('wechat')}</div>
+                  <div class="hint">${t('wechatHint')}</div>
+                </div>
+              </div>
+              <div class="toggle ${wechatEnabled ? 'active' : ''}" data-toggle-messenger="wechat-ilink"></div>
+            </div>
+            ${wechatEnabled ? `<div class="hint-box">${t('wechatBox')}</div>` : ''}
+          </div>
+
+          <!-- Telegram -->
+          <div style="margin-bottom:16px">
+            <div class="agent-row">
+              <div class="left">
+                <div>
+                  <div class="name">${t('telegram')}</div>
+                  <div class="hint">${t('telegramHint')}</div>
+                </div>
+              </div>
+              <div class="toggle ${telegramEnabled ? 'active' : ''}" data-toggle-messenger="telegram"></div>
+            </div>
+            ${telegramEnabled ? `
+              <div class="row">
+                <div>
+                  <label>${t('botToken')}</label>
+                  <input type="password" id="tgToken" value="${tg.botToken || ''}" placeholder="123456:ABC-DEF...">
+                </div>
+                <div>
+                  <label>${t('channelId')}</label>
+                  <input type="text" id="tgChannel" value="${tg.channelId || ''}" placeholder="default">
+                </div>
+              </div>
+            ` : ''}
+          </div>
+
+          <!-- Feishu -->
+          <div>
+            <div class="agent-row">
+              <div class="left">
+                <div>
+                  <div class="name">${t('feishu')}</div>
+                  <div class="hint">${t('feishuHint')}</div>
+                </div>
+              </div>
+              <div class="toggle ${feishuEnabled ? 'active' : ''}" data-toggle-messenger="feishu"></div>
+            </div>
+            ${feishuEnabled ? `
+              <div class="row">
+                <div>
+                  <label>${t('appId')}</label>
+                  <input type="text" id="fsAppId" value="${fs.appId || ''}" placeholder="cli_xxx">
+                </div>
+                <div>
+                  <label>${t('appSecret')}</label>
+                  <input type="password" id="fsAppSecret" value="${fs.appSecret || ''}" placeholder="Your app secret">
+                </div>
+              </div>
+            ` : ''}
+          </div>
+
+          <div class="actions">
+            <button class="btn btn-primary" id="saveMessengers">${t('saveMessengers')}</button>
+          </div>
+        </div>
+      `;
+    }
+
+    // ==========================================
+    // ACP Remote Agents card
+    // ==========================================
+    function renderAcpCard() {
+      const agents = config.acpAgents || [];
+
+      const rows = agents.length > 0 ? agents.map((a, i) => `
+        <tr data-acp-idx="${i}">
+          <td><strong>${a.name}</strong><br><span style="font-size:11px;color:var(--text-dim)">${(a.aliases || []).join(', ')}</span></td>
+          <td style="font-family:monospace;font-size:12px">${a.endpoint}</td>
+          <td>${a.auth?.type || t('none')}</td>
+          <td><div class="toggle ${a.enabled !== false ? 'active' : ''}" data-toggle-acp="${i}"></div></td>
+          <td>
+            <button class="btn btn-sm" data-test-acp="${i}">${t('test')}</button>
+            <button class="btn btn-sm btn-danger" data-del-acp="${i}">${t('del')}</button>
+          </td>
+        </tr>
+      `).join('') : `<tr><td colspan="5" style="color:var(--text-dim);text-align:center;padding:20px">${t('acpNone')}</td></tr>`;
+
+      return `
+        <div class="card">
+          <h2>${t('acpTitle')} <span class="badge">${agents.length}</span></h2>
+
+          <table class="acp-table">
+            <thead>
+              <tr><th>${t('name')}</th><th>${t('endpoint')}</th><th>${t('auth')}</th><th>${t('enabled')}</th><th></th></tr>
+            </thead>
+            <tbody>
+              ${rows}
+            </tbody>
+          </table>
+
+          <hr class="divider">
+          <div style="font-size:13px;font-weight:600;margin-bottom:10px">${t('addAgent')}</div>
+          <div class="row">
+            <div>
+              <label>${t('name')}</label>
+              <input type="text" id="acpName" placeholder="my-agent">
+            </div>
+            <div>
+              <label>${t('aliases')}</label>
+              <input type="text" id="acpAliases" placeholder="ma, agent1">
+            </div>
+          </div>
+          <div class="row">
+            <div>
+              <label>${t('endpointUrl')}</label>
+              <input type="text" id="acpEndpoint" placeholder="http://localhost:8080">
+            </div>
+            <div>
+              <label>${t('authType')}</label>
+              <select id="acpAuthType">
+                <option value="none">${t('none')}</option>
+                <option value="apikey">${t('apikey')}</option>
+                <option value="bearer">${t('bearer')}</option>
+              </select>
+            </div>
+          </div>
+          <div class="row" id="acpTokenRow" style="display:none">
+            <div>
+              <label>${t('token')}</label>
+              <input type="password" id="acpToken" placeholder="Your auth token">
+            </div>
+            <div></div>
+          </div>
+          <div class="actions">
+            <button class="btn" id="testAcpNew">${t('testConn')}</button>
+            <button class="btn btn-primary" id="addAcp">${t('add')}</button>
+          </div>
+        </div>
+      `;
+    }
+
+    // ==========================================
+    // General card
+    // ==========================================
+    function renderGeneralCard() {
+      return `
+        <div class="card">
+          <h2>${t('general')}</h2>
+          <label>${t('webPort')}</label>
+          <input type="number" id="webPort" value="${config.webPort || 3000}" min="1024" max="65535" style="max-width:200px">
+          <div class="actions">
+            <button class="btn btn-primary" id="saveGeneral">${t('save')}</button>
+          </div>
+        </div>
+      `;
+    }
+
+    // ==========================================
+    // Event binding
+    // ==========================================
+    function bindEvents() {
+      // Agent toggles
+      document.querySelectorAll('[data-toggle-agent]').forEach(el => {
+        el.addEventListener('click', () => el.classList.toggle('active'));
+      });
+
+      // Messenger toggles
+      document.querySelectorAll('[data-toggle-messenger]').forEach(el => {
+        el.addEventListener('click', () => {
+          el.classList.toggle('active');
+          syncMessengerToggles();
+        });
+      });
+
+      // ACP toggles
+      document.querySelectorAll('[data-toggle-acp]').forEach(el => {
+        el.addEventListener('click', () => el.classList.toggle('active'));
+      });
+
+      // ACP delete buttons
+      document.querySelectorAll('[data-del-acp]').forEach(btn => {
+        btn.addEventListener('click', async () => {
+          const idx = parseInt(btn.dataset.delAcp);
+          config.acpAgents.splice(idx, 1);
+          await saveConfig();
+          render();
+        });
+      });
+
+      // ACP test existing
+      document.querySelectorAll('[data-test-acp]').forEach(btn => {
+        btn.addEventListener('click', async () => {
+          const idx = parseInt(btn.dataset.testAcp);
+          const agent = config.acpAgents[idx];
+          btn.disabled = true;
+          btn.textContent = t('testing');
+          try {
+            const res = await fetch('/api/agents/acp/test', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ endpoint: agent.endpoint, auth: agent.auth }),
+            });
+            const data = await res.json();
+            if (data.ok) {
+              toast(`${t('connected')}: ${data.name}`, 'success');
+            } else {
+              toast(`${t('failed')}: ${data.error}`, 'error');
+            }
+          } catch (err) {
+            toast(`${t('error')}: ${err.message}`, 'error');
+          }
+          btn.disabled = false;
+          btn.textContent = t('test');
+        });
+      });
+
+      // ACP auth type toggle
+      const acpAuthType = document.getElementById('acpAuthType');
+      if (acpAuthType) {
+        acpAuthType.addEventListener('change', () => {
+          const row = document.getElementById('acpTokenRow');
+          row.style.display = acpAuthType.value === 'none' ? 'none' : 'flex';
+        });
+      }
+
+      // Save agents
+      document.getElementById('saveAgents')?.addEventListener('click', async () => {
+        const enabled = [];
+        document.querySelectorAll('[data-toggle-agent]').forEach(el => {
+          if (el.classList.contains('active')) {
+            enabled.push(el.dataset.toggleAgent);
+          }
+        });
+        const defaultAgent = document.getElementById('defaultAgent').value;
+        config.agents = enabled;
+        config.defaultAgent = defaultAgent;
+        await saveConfig();
+      });
+
+      // Save messengers
+      document.getElementById('saveMessengers')?.addEventListener('click', async () => {
+        const enabled = [];
+        document.querySelectorAll('[data-toggle-messenger]').forEach(el => {
+          if (el.classList.contains('active')) {
+            enabled.push(el.dataset.toggleMessenger);
+          }
+        });
+        config.messengers = enabled;
+
+        const tgToken = document.getElementById('tgToken');
+        const tgChannel = document.getElementById('tgChannel');
+        if (tgToken) {
+          const val = tgToken.value.trim();
+          if (val && !val.includes('****')) {
+            config.telegram = { botToken: val, channelId: tgChannel?.value.trim() || 'default' };
+          }
+        } else {
+          delete config.telegram;
+        }
+
+        const fsAppId = document.getElementById('fsAppId');
+        const fsAppSecret = document.getElementById('fsAppSecret');
+        if (fsAppId) {
+          const id = fsAppId.value.trim();
+          const secret = fsAppSecret.value.trim();
+          if (id && secret && !secret.includes('****')) {
+            config.feishu = { appId: id, appSecret: secret };
+          }
+        } else {
+          delete config.feishu;
+        }
+
+        await saveConfig();
+      });
+
+      // Test new ACP
+      document.getElementById('testAcpNew')?.addEventListener('click', async () => {
+        const endpoint = document.getElementById('acpEndpoint').value.trim();
+        if (!endpoint) { toast(t('enterEndpoint'), 'error'); return; }
+
+        const authType = document.getElementById('acpAuthType').value;
+        const token = document.getElementById('acpToken')?.value.trim();
+        const auth = authType === 'none' ? undefined : { type: authType, token };
+        const btn = document.getElementById('testAcpNew');
+        btn.disabled = true;
+        btn.textContent = t('testing');
+
+        try {
+          const res = await fetch('/api/agents/acp/test', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ endpoint, auth }),
+          });
+          const data = await res.json();
+          if (data.ok) {
+            toast(`${t('connected')}: ${data.name}${data.description ? ' — ' + data.description : ''}`, 'success');
+          } else {
+            toast(`${t('failed')}: ${data.error}`, 'error');
+          }
+        } catch (err) {
+          toast(`${t('error')}: ${err.message}`, 'error');
+        }
+        btn.disabled = false;
+        btn.textContent = t('testConn');
+      });
+
+      // Add ACP
+      document.getElementById('addAcp')?.addEventListener('click', async () => {
+        const name = document.getElementById('acpName').value.trim();
+        const endpoint = document.getElementById('acpEndpoint').value.trim();
+        if (!name) { toast(t('nameRequired'), 'error'); return; }
+        if (!endpoint) { toast(t('endpointRequired'), 'error'); return; }
+
+        const aliases = document.getElementById('acpAliases').value.split(',').map(s => s.trim()).filter(Boolean);
+        const authType = document.getElementById('acpAuthType').value;
+        const token = document.getElementById('acpToken')?.value.trim();
+        const auth = authType === 'none' ? undefined : { type: authType, token };
+
+        if (!config.acpAgents) config.acpAgents = [];
+        config.acpAgents.push({ name, aliases, endpoint, auth, enabled: true });
+        await saveConfig();
+        render();
+      });
+
+      // Save general
+      document.getElementById('saveGeneral')?.addEventListener('click', async () => {
+        config.webPort = parseInt(document.getElementById('webPort').value) || 3000;
+        await saveConfig();
+      });
+    }
+
+    function syncMessengerToggles() {
+      render();
+    }
+
+    // ==========================================
+    // API helpers
+    // ==========================================
+    async function saveConfig() {
+      try {
+        const payload = {
+          messengers: config.messengers,
+          agents: config.agents,
+          defaultAgent: config.defaultAgent,
+          telegram: config.telegram,
+          feishu: config.feishu,
+          acpAgents: config.acpAgents,
+          webPort: config.webPort,
+        };
+
+        const res = await fetch('/api/config', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+
+        if (!res.ok) {
+          const data = await res.json();
+          throw new Error(data.error || t('saveFailed'));
+        }
+
+        toast(t('savedMsg'), 'success');
+        await init();
+      } catch (err) {
+        toast(`${t('saveFailed')}: ${err.message}`, 'error');
+      }
+    }
+
+    let toastTimer;
+    function toast(msg, type) {
+      toastEl.textContent = msg;
+      toastEl.className = `toast ${type} show`;
+      clearTimeout(toastTimer);
+      toastTimer = setTimeout(() => {
+        toastEl.classList.remove('show');
+      }, 3000);
+    }
+
+    // Init
+    applyLang();
+    init();
+  </script>
+</body>
+</html>

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -1,0 +1,381 @@
+// Web chat server — HTTP + WebSocket for browser-based agent interaction
+
+import { createServer, type IncomingMessage, type ServerResponse } from 'http'
+import { readFileSync, existsSync } from 'fs'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { WebSocketServer, type WebSocket } from 'ws'
+import { parseMessage, routeMessage } from '../core/router.js'
+import { sessionManager } from '../core/session.js'
+import { registry } from '../core/registry.js'
+import {
+  isAgentAvailableCached,
+  loadConfig,
+  saveConfig,
+  type Config,
+} from '../core/onboarding.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const PUBLIC_DIR = join(__dirname, 'public')
+const DEFAULT_PORT = 3000
+
+interface ClientConnection {
+  ws: WebSocket
+  id: string
+  agent: string
+}
+
+/**
+ * Start the web chat server
+ */
+export async function startWebServer(options: {
+  port?: number
+  defaultAgent: string
+}): Promise<{ close: () => void; port: number }> {
+  const port = options.port || DEFAULT_PORT
+  const clients = new Map<string, ClientConnection>()
+
+  // HTTP request handler — static files + REST API
+  const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    const url = new URL(req.url || '/', `http://localhost:${port}`)
+
+    // Static pages
+    if (url.pathname === '/' || url.pathname === '/index.html') {
+      return serveStatic(res, join(PUBLIC_DIR, 'index.html'), 'text/html')
+    }
+    if (url.pathname === '/settings' || url.pathname === '/settings.html') {
+      return serveStatic(res, join(PUBLIC_DIR, 'settings.html'), 'text/html')
+    }
+
+    // REST API
+    if (url.pathname === '/api/config' && req.method === 'GET') {
+      return handleGetConfig(req, res)
+    }
+    if (url.pathname === '/api/config' && req.method === 'PUT') {
+      return handlePutConfig(req, res)
+    }
+    if (url.pathname === '/api/agents/status' && req.method === 'GET') {
+      return handleAgentsStatus(req, res)
+    }
+    if (url.pathname === '/api/agents/acp/test' && req.method === 'POST') {
+      return handleAcpTest(req, res)
+    }
+
+    res.writeHead(404)
+    res.end('Not found')
+  })
+
+  // WebSocket server
+  const wss = new WebSocketServer({ server: httpServer })
+
+  wss.on('connection', (ws: WebSocket) => {
+    const clientId = `web-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    const client: ClientConnection = { ws, id: clientId, agent: options.defaultAgent }
+    clients.set(clientId, client)
+
+    console.log(`[Web] Client connected: ${clientId}`)
+
+    // Send available agents list
+    sendToClient(ws, {
+      type: 'init',
+      agents: registry.listAgents(),
+      defaultAgent: options.defaultAgent,
+      clientId,
+    })
+
+    // Load existing session history if available
+    sendSessionHistory(ws, clientId, options.defaultAgent)
+
+    ws.on('message', async (data: Buffer) => {
+      try {
+        const msg = JSON.parse(data.toString())
+        await handleClientMessage(client, msg, options.defaultAgent)
+      } catch (err) {
+        console.error('[Web] Error parsing message:', err)
+        sendToClient(ws, { type: 'error', message: 'Invalid message format' })
+      }
+    })
+
+    ws.on('close', () => {
+      console.log(`[Web] Client disconnected: ${clientId}`)
+      clients.delete(clientId)
+    })
+
+    ws.on('error', (err) => {
+      console.error(`[Web] Client error: ${clientId}`, err)
+      clients.delete(clientId)
+    })
+  })
+
+  // Start listening
+  await new Promise<void>((resolve, reject) => {
+    httpServer.on('error', reject)
+    httpServer.listen(port, () => resolve())
+  })
+
+  console.log(`[Web] Chat UI available at http://localhost:${port}`)
+
+  return {
+    port,
+    close: () => {
+      // Close all WebSocket connections
+      for (const [id, client] of clients) {
+        client.ws.close()
+        clients.delete(id)
+      }
+      wss.close()
+      httpServer.close()
+    },
+  }
+}
+
+// ============================================
+// REST API handlers
+// ============================================
+
+async function handleGetConfig(_req: IncomingMessage, res: ServerResponse): Promise<void> {
+  try {
+    const config = await loadConfig()
+    const agentStatus = await getAgentStatuses()
+
+    sendJson(res, 200, {
+      messengers: config.messengers,
+      agents: config.agents,
+      defaultAgent: config.defaultAgent,
+      telegram: config.telegram
+        ? { botToken: mask(config.telegram.botToken), channelId: config.telegram.channelId }
+        : undefined,
+      feishu: config.feishu
+        ? { appId: config.feishu.appId, appSecret: mask(config.feishu.appSecret) }
+        : undefined,
+      acpAgents: config.acpAgents?.map(a => ({
+        ...a,
+        auth: a.auth
+          ? { ...a.auth, token: a.auth.token ? mask(a.auth.token) : undefined }
+          : undefined,
+      })),
+      webPort: config.webPort,
+      agentStatus,
+    })
+  } catch (err) {
+    sendJson(res, 500, { error: 'Failed to load config' })
+  }
+}
+
+async function handlePutConfig(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  try {
+    const body = await readBody(req)
+    const incoming = JSON.parse(body) as Config
+
+    // Merge with existing config — only overwrite fields that are present
+    const existing = await loadConfig()
+
+    // Simple merge: incoming fields overwrite existing
+    const merged: Config = {
+      ...existing,
+      ...incoming,
+    }
+
+    await saveConfig(merged)
+    sendJson(res, 200, { ok: true })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    sendJson(res, 400, { error: msg })
+  }
+}
+
+async function handleAgentsStatus(_req: IncomingMessage, res: ServerResponse): Promise<void> {
+  try {
+    const agentStatus = await getAgentStatuses()
+    sendJson(res, 200, agentStatus)
+  } catch (err) {
+    sendJson(res, 500, { error: 'Failed to check agents' })
+  }
+}
+
+async function handleAcpTest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  try {
+    const body = await readBody(req)
+    const { endpoint, auth } = JSON.parse(body)
+
+    // Dynamic import to avoid circular deps
+    const { ACPClient } = await import('../plugins/agents/acp/acp-client.js')
+    const client = new ACPClient({ name: 'test', endpoint, auth })
+    const manifest = await client.fetchManifest()
+
+    sendJson(res, 200, {
+      ok: true,
+      name: manifest.name,
+      description: manifest.description,
+    })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    sendJson(res, 400, { ok: false, error: msg })
+  }
+}
+
+// ============================================
+// Helpers
+// ============================================
+
+async function getAgentStatuses(): Promise<Record<string, boolean>> {
+  const agents = registry.listAgents()
+  const status: Record<string, boolean> = {}
+  await Promise.all(
+    agents.map(async (name) => {
+      const agent = registry.findAgent(name)
+      if (agent) {
+        try {
+          status[name] = await agent.isAvailable()
+        } catch {
+          status[name] = false
+        }
+      }
+    })
+  )
+  return status
+}
+
+function mask(value: string | undefined): string {
+  if (!value) return ''
+  if (value.length <= 4) return '****'
+  return value.slice(0, 2) + '****' + value.slice(-2)
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let body = ''
+    req.on('data', (chunk: Buffer) => { body += chunk.toString() })
+    req.on('end', () => resolve(body))
+    req.on('error', reject)
+  })
+}
+
+function sendJson(res: ServerResponse, status: number, data: unknown): void {
+  res.writeHead(status, { 'Content-Type': 'application/json' })
+  res.end(JSON.stringify(data))
+}
+
+// ============================================
+// WebSocket chat handlers
+// ============================================
+
+/**
+ * Handle a message from a web client
+ */
+async function handleClientMessage(
+  client: ClientConnection,
+  msg: { type: string; text?: string; agent?: string },
+  defaultAgent: string
+): Promise<void> {
+  const { ws, id: clientId } = client
+
+  switch (msg.type) {
+    case 'message': {
+      if (!msg.text?.trim()) return
+
+      const text = msg.text.trim()
+
+      // Handle agent switch request
+      if (msg.agent && msg.agent !== client.agent) {
+        client.agent = msg.agent
+      }
+
+      // Parse and route through existing router
+      const parsed = parseMessage(text)
+
+      try {
+        const result = await routeMessage(parsed, {
+          threadId: clientId,
+          channelId: 'web',
+          platform: 'web',
+          defaultAgent: client.agent,
+        })
+
+        // String response (built-in commands, errors)
+        if (typeof result === 'string') {
+          sendToClient(ws, { type: 'done', text: result })
+          return
+        }
+
+        // Streaming response (agent responses)
+        let fullText = ''
+        for await (const chunk of result) {
+          fullText += chunk
+          sendToClient(ws, { type: 'chunk', text: chunk })
+        }
+        sendToClient(ws, { type: 'done', text: fullText })
+      } catch (err) {
+        const errorMsg = err instanceof Error ? err.message : String(err)
+        console.error('[Web] Error handling message:', errorMsg)
+        sendToClient(ws, { type: 'error', message: `Agent error: ${errorMsg}` })
+      }
+      break
+    }
+
+    case 'switch-agent': {
+      if (!msg.agent) return
+      const agent = registry.findAgent(msg.agent)
+      if (!agent) {
+        sendToClient(ws, { type: 'error', message: `Agent "${msg.agent}" not found` })
+        return
+      }
+      if (!(await isAgentAvailableCached(agent.name))) {
+        sendToClient(ws, { type: 'error', message: `Agent "${agent.name}" is not available` })
+        return
+      }
+      client.agent = agent.name
+      await sessionManager.switchAgent('web', 'web', clientId, agent.name)
+      sendToClient(ws, { type: 'agent-switched', agent: agent.name })
+      break
+    }
+
+    case 'get-agents': {
+      const agents = registry.listAgents()
+      sendToClient(ws, { type: 'agents', agents })
+      break
+    }
+
+    case 'get-history': {
+      await sendSessionHistory(ws, clientId, defaultAgent)
+      break
+    }
+  }
+}
+
+/**
+ * Send session history to a client
+ */
+async function sendSessionHistory(ws: WebSocket, clientId: string, defaultAgent: string): Promise<void> {
+  const history = await sessionManager.getSessionWithHistory('web', 'web', clientId)
+  if (history && history.messages.length > 0) {
+    sendToClient(ws, {
+      type: 'history',
+      messages: history.messages,
+      agent: history.session.agent,
+    })
+  }
+}
+
+/**
+ * Send a JSON message to a WebSocket client
+ */
+function sendToClient(ws: WebSocket, data: Record<string, unknown>): void {
+  if (ws.readyState === ws.OPEN) {
+    ws.send(JSON.stringify(data))
+  }
+}
+
+/**
+ * Serve a static file
+ */
+function serveStatic(res: ServerResponse, filePath: string, contentType: string): void {
+  if (!existsSync(filePath)) {
+    res.writeHead(404)
+    res.end('Not found')
+    return
+  }
+  const content = readFileSync(filePath)
+  res.writeHead(200, { 'Content-Type': contentType })
+  res.end(content)
+}


### PR DESCRIPTION
- Add lightweight i18n system to index.html and settings.html
- Auto-detect browser language, persist choice in localStorage
- Language selector in both chat and settings page headers
- Translate all UI strings (status, labels, buttons, placeholders, hints)
- Update README.md and README.zh-CN.md with web chat docs and v0.2.x roadmap