### PR TITLE
fix: agent routing, session persistence, Windows compatibility, and error handling

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -96,9 +96,11 @@ program
       console.log('')
     }
 
-    // Set defaultAgent to first available installed agent
+    // Set defaultAgent to first available installed agent (only if configured one is unavailable)
     if (agentResult.available.length > 0) {
-      config.defaultAgent = agentResult.available[0]
+      if (!config.defaultAgent || !agentResult.available.includes(config.defaultAgent)) {
+        config.defaultAgent = agentResult.available[0]
+      }
     }
 
     // ============================================

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -51,8 +51,11 @@ class SessionManager {
         // Expired — create new
         session = undefined
       } else {
-        // Update activity
+        // Update activity and agent if changed
         session.lastActivity = now
+        if (session.agent !== agent) {
+          session.agent = agent
+        }
         await this.saveSession(key, session)
         return session
       }
@@ -62,8 +65,11 @@ class SessionManager {
     session = await this.loadSession(key)
 
     if (session && now.getTime() - session.lastActivity.getTime() <= session.ttl) {
-      // Found and valid
+      // Found and valid — update agent if changed
       session.lastActivity = now
+      if (session.agent !== agent) {
+        session.agent = agent
+      }
       this.sessions.set(key, session)
       await this.saveSession(key, session)
       return session

--- a/src/plugins/agents/opencode/index.ts
+++ b/src/plugins/agents/opencode/index.ts
@@ -15,8 +15,16 @@ interface OpenCodeEvent {
   text?: string
   message?: string
   error?: string
+  sessionID?: string
   part?: OpenCodePart
 }
+
+interface CallResult {
+  text: string
+  sessionId: string | null
+}
+
+const sessionMap = new Map<string, string>()
 
 export class OpenCodeAdapter implements AgentAdapter {
   readonly name = 'opencode'
@@ -30,45 +38,32 @@ export class OpenCodeAdapter implements AgentAdapter {
     })
   }
 
-  async *sendPrompt(_sessionId: string, prompt: string, history?: ChatMessage[]): AsyncGenerator<string> {
+  async *sendPrompt(sessionId: string, prompt: string, history?: ChatMessage[]): AsyncGenerator<string> {
     console.log(`[OpenCode] sendPrompt called, prompt: ${prompt}, history: ${history?.length || 0} messages`)
 
-    // Build prompt with conversation context
-    const contextualPrompt = this.buildContextualPrompt(prompt, history)
+    const ocSessionId = sessionMap.get(sessionId)
+    const result = await this.callOpenCode(prompt, ocSessionId ?? null)
 
-    const response = await this.callOpenCode(contextualPrompt)
-    console.log(`[OpenCode] Response length: ${response.length}`)
+    if (result.sessionId) {
+      sessionMap.set(sessionId, result.sessionId)
+    }
 
-    if (response) {
-      yield response
+    console.log(`[OpenCode] Response length: ${result.text.length}`)
+
+    if (result.text) {
+      yield result.text
     }
   }
 
-  /**
-   * Build prompt with conversation history context
-   */
-  private buildContextualPrompt(prompt: string, history?: ChatMessage[]): string {
-    if (!history || history.length === 0) {
-      return prompt
-    }
-
-    const historyText = history
-      .map(msg => `[${msg.role === 'user' ? 'User' : 'Assistant'}]: ${msg.content}`)
-      .join('\n\n')
-
-    return `Previous conversation context:
-${historyText}
-
-Current request: ${prompt}`
-  }
-
-  private callOpenCode(prompt: string): Promise<string> {
+  private callOpenCode(prompt: string, existingOcSessionId: string | null): Promise<CallResult> {
     return new Promise((resolve, reject) => {
-      const proc = crossSpawn('opencode', [
-        'run',
-        '--format', 'json',
-        prompt,
-      ], {
+      const args = ['run', '--format', 'json']
+      if (existingOcSessionId) {
+        args.push('--session', existingOcSessionId)
+      }
+      args.push(prompt)
+
+      const proc = crossSpawn('opencode', args, {
         stdio: ['ignore', 'pipe', 'pipe'],
       })
 
@@ -76,6 +71,7 @@ Current request: ${prompt}`
       let stderr = ''
       let fullText = ''
       let errorMessage = ''
+      let ocSessionId: string | null = existingOcSessionId ?? null
 
       proc.stdout?.on('data', (data: Buffer) => {
         stdout += data.toString()
@@ -88,6 +84,12 @@ Current request: ${prompt}`
           try {
             const event: OpenCodeEvent = JSON.parse(line)
             console.log('[OpenCode] Event:', JSON.stringify(event))
+
+            // Capture the opencode session ID from the first event
+            if (!ocSessionId && event.sessionID) {
+              ocSessionId = event.sessionID
+              console.log('[OpenCode] Captured session ID:', ocSessionId)
+            }
 
             // Capture error message
             if (event.type === 'error') {
@@ -114,20 +116,18 @@ Current request: ${prompt}`
       })
 
       proc.on('close', (code) => {
-        console.log('[OpenCode] Process closed, code:', code)
-        if (code !== 0) {
-          // Return user-friendly error message
-          let errorMsg = 'OpenCode 执行失败'
-          if (errorMessage.includes('auth') || errorMessage.includes('login')) {
-            errorMsg = 'OpenCode 未登录或认证已过期'
-          } else if (errorMessage.includes('API') || errorMessage.includes('key')) {
-            errorMsg = 'OpenCode API 密钥无效'
-          } else if (errorMessage.length > 0 && errorMessage.length < 100) {
-            errorMsg = errorMessage
+        console.log('[OpenCode] Process closed, code:', code, 'stderr:', stderr)
+        // If we got text output, return it even if exit code != 0 (tool errors)
+        if (fullText) {
+          resolve({ text: fullText, sessionId: ocSessionId })
+        } else if (code !== 0) {
+          let errorMsg = stderr.trim() || errorMessage || 'OpenCode 执行失败'
+          if (errorMsg.length > 200) {
+            errorMsg = errorMsg.substring(0, 200) + '...'
           }
-          resolve(`❌ OpenCode 错误: ${errorMsg}\n\n请运行 \`opencode auth login\` 配置认证。`)
+          resolve({ text: `❌ OpenCode 错误: ${errorMsg}`, sessionId: ocSessionId })
         } else {
-          resolve(fullText)
+          resolve({ text: fullText, sessionId: ocSessionId })
         }
       })
     })

--- a/src/utils/cross-platform.ts
+++ b/src/utils/cross-platform.ts
@@ -24,6 +24,7 @@ export function crossSpawn(
     // On Windows, we need shell: true for commands like 'claude', 'opencode', etc.
     // to be found in PATH and executed properly.
     shell: isWindows ? (options.shell ?? true) : options.shell,
+    windowsHide: isWindows ? true : options.windowsHide,
   }
   return spawn(command, args, spawnOptions)
 }


### PR DESCRIPTION
## Summary

Fixes 4 bugs discovered during OpenCode + WeChat integration on Windows:

### 1. DefaultAgent overwritten at startup (\src/cli.ts\)
\config.defaultAgent\ was unconditionally set to the first available agent, ignoring the user's configuration. Now only falls back when the configured agent is unavailable.

### 2. Session agent stale after config change (\src/core/session.ts\)
\getOrCreateSession\ loaded existing sessions from disk without checking if the stored agent matches the current config. After switching from claude-code to opencode, old sessions still routed to claude-code. Now updates the agent field on mismatch.

### 3. CMD window flash on Windows (\src/utils/cross-platform.ts\)
\crossSpawn\ did not set \windowsHide: true\, causing a visible CMD window to pop up for every spawned process on Windows.

### 4. OpenCode session management overhaul (\src/plugins/agents/opencode/index.ts\)
- Captures OpenCode session ID from the first JSON event and reuses it via \--session\ for subsequent messages, maintaining proper conversation continuity
- Prefers text output over stderr when process exits non-zero (tool errors shouldn't mask useful responses)
- Removed \uildContextualPrompt\ which was passing history as prompt text — now OpenCode maintains its own session state